### PR TITLE
Added sizeof to grammar

### DIFF
--- a/src/backend/parser/assets/ansic.jison
+++ b/src/backend/parser/assets/ansic.jison
@@ -345,7 +345,10 @@ unary_expression
     | unary_operator cast_expression
         { $$ = uexp("UNARYOP_" + $1, $2); }
 /*    | SIZEOF unary_expression  */
-/*    | SIZEOF '(' type_name ')' */
+    | SIZEOF '(' type_specifier ')'
+        { $$ = nullexp("SIZEOF", $3); }
+    | SIZEOF '(' type_specifier '*' ')'
+        { $$ = nullexp("SIZEOF", { type: "pointer", tvalue: $3 }); }
     ;
 
 unary_operator

--- a/test/backend/parser/GrammarTest.js
+++ b/test/backend/parser/GrammarTest.js
@@ -120,6 +120,12 @@ describe("Parser Grammar", function() {
             options: { locations: true },
             expected: "ok",
         },
+        {
+            description: "Sizeof",
+            file: "sizeof",
+            options: { locations: false },
+            expected: "ok",
+        },
         // bad
         {
             description: "Bad - Hello World",

--- a/test/backend/parser/assets/ast/sizeof.ast
+++ b/test/backend/parser/assets/ast/sizeof.ast
@@ -1,0 +1,47 @@
+{
+    "type": "translation_unit",
+    "external_declarations": [
+        {
+            "type": "function_definition",
+            "declaration": {
+                "type": "function_declaration",
+                "name": "main",
+                "param_tvalues": [],
+                "param_names": [],
+                "return_tvalue": {
+                    "type": "concrete_type",
+                    "name": "int"
+                }
+            },
+            "body": {
+                "type": "compound_statement",
+                "declarations": [],
+                "statements": [
+                    {
+                        "type": "expression_statement",
+                        "expression": {
+                            "type": "SIZEOF",
+                            "value": {
+                                "type": "concrete_type",
+                                "name": "int"
+                            }
+                        }
+                    },
+                    {
+                        "type": "expression_statement",
+                        "expression": {
+                            "type": "SIZEOF",
+                            "value": {
+                                "type": "pointer",
+                                "tvalue": {
+                                    "type": "concrete_type",
+                                    "name": "char"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/test/backend/parser/assets/programs/sizeof.c
+++ b/test/backend/parser/assets/programs/sizeof.c
@@ -1,0 +1,5 @@
+int main(void)
+{
+    sizeof(int);
+    sizeof(char*);
+}


### PR DESCRIPTION
Support limited to: sizeof(type) | sizeof(type*)
